### PR TITLE
OOBM interface needs to be handled differently

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -377,7 +377,10 @@ class ProcurveDriver(NetworkDriver):
         lldp = {}
         ifs = self._get_interface_map()
 
-        command = "show lldp info remote-device ethernet {}".format(interface)
+        if interface == 'OOBM':
+            command = "show lldp info remote-device oobm"
+        else:
+            command = "show lldp info remote-device ethernet {}".format(interface)
         output = self._send_command(command)
 
         key_mib_table = {'System Descr': 'lldpRemSysDesc',


### PR DESCRIPTION
On our "HP J9728A 2920-48G Switch" with OS version WB.16.03.0003 `self._lldp_detail_parser(interface)` returned an empty dict for the OOBM interface as it needs to be queried differently.

I hope this small patch helps fixing it for other switches as well without breaking it on others.