### PR TITLE
get_facts() - Patch for stacking

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -403,6 +403,7 @@ class ProcurveDriver(NetworkDriver):
         output = self._send_command(command)
 
         key_mib_table = {
+            "ChassisId": "lldpRemChassisId",
             "System Descr": "lldpRemSysDesc",
             "PortId": "lldpRemPortId",
             "PortType": "lldpRemPortIdSubtype",

--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -710,6 +710,9 @@ class ProcurveDriver(NetworkDriver):
         for line in output.splitlines():
             if len(line.split()) == 4:
                 address, mac, eth_type, port = line.split()
+            # Bug: Type static (old firmware)
+            elif len(line.split()) == 3:
+                address, mac, eth_type = line.split()
             else:
                 raise ValueError("Unexpected output from: {}".format(line.split()))
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,16 @@ import uuid
 
 from setuptools import setup, find_packages
 try:
+    # pip>=21.x.x
+    from pip._internal.req.constructors import (
+        install_req_from_parsed_requirement,
+    )
+except ImportError:
+    # pip<=20.x.x
+    def install_req_from_parsed_requirement(x):
+        return x
+
+try:
     # pip >=20
     from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
@@ -19,6 +29,8 @@ except ImportError:
 __author__ = 'Andreas Thienemann <andreas@bawue.net>'
 
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
+install_reqs = [install_req_from_parsed_requirement(req) for req in install_reqs]
+
 reqs = [str(ir.req) for ir in install_reqs]
 
 setup(


### PR DESCRIPTION
### **Error in devices with _stacking modules_**:

> Traceback (most recent call last):
>   File "commands_stack.py", line 19, in <module>
>     out = device.get_facts()
>   File "/usr/local/lib/python3.8/dist-packages/napalm_procurve/procurve.py", line 236, in get_facts
>     int(float(uptime["s"]))
> KeyError: 's'


### **Solution**:
 
>    Patch _get_facts()_ function
  
### **Note**: 

   Members stacked using _stacking modules_:
        
>         - 1 IP for all members
>         - get_facts returns one serial number per member
>              Example for 3 members: 'serial_number': 'SGBBBBBBBB SGCCCCCCCC SGDDDDDDDD'

### **Patch tested on**: 

>    HP2920 48G  - J9729A (using HP J9733A 2-port Stacking Module)
>    HP2530 48G  - J9772A   
>    HP3400CL    - J4905A
>    HP2626      - J4900B
>    HP2810 48G  - J9022A
>    HP2848      - J4904A
>    HP2650      - J4899A (with stacking)
 
### **Firmware output commands**:
 
 **a. show uptime** 
	  
 1. Output type 1 example:
            
			0176:05:00:58.87
			
  2. Output type 2 example (3 members stacked):
            
			 Stack 
                     176d 1h 59m 

                     Member 1
                     176d 1h 59m 

                     Member 2
                     176d 1h 58m 

                     Member 3
                     176d 2h 2m

 **b. show system** 
	  
   1. Example 1 (without stacking modules):
			
      a) Output
			
          Status and Counters - General System Information

           System Name        : SWITCH-1                           
           System Contact     : 
           System Location    : 

           MAC Age Time (sec) : 300    

           Time Zone          : 60   
           Daylight Time Rule : Western-Europe            

           Software revision  : WB.15.15.0010        Base MAC Addr      : 111111-111111
           ROM Version        : WB.15.05             Serial Number      : SGAAAAAAAA  

           Up Time            : 176 days             Memory   - Total   : 169,759,232 
           CPU Util (%)       : 2                               Free    : 83,657,648  

           IP Mgmt  - Pkts Rx : 30,833,979           Packet   - Total   : 6750        
             Pkts Tx : 6,457,026            Buffers    Free    : 5009        
                                                       Lowest  : 4796        
                                                       Missed  : 0 

      b) get_facts result:

> {'uptime': 15224461, 'vendor': 'Hewlett-Packard', 'os_version': 'WB.15.15.0010', 'serial_number': 'SGAAAAAAAA', 'model': 'HP J9729A 2920-48G-POE+ Switch', 'hostname': 'SWITCH-1', 'fqdn': 'Unknown', 'interface_list': ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48']}

	  
 2. Example 2 (with stacking modules):
			
      a) Output

          Status and Counters - General System Information
 
            System Name        : STACK-3-UNITS                 
            System Contact     : 
            System Location    : 
            MAC Age Time (sec) : 300    
            Time Zone          : 60   
            Daylight Time Rule : Western-Europe            
 
            Software revision  : WB.16.02.0028      
            Base MAC Addr      : 222222-222222
 
           Member :1
 
            ROM Version        : WB.16.03                      
            Up Time            : 176 days       
            CPU Util (%)       : 17          
            MAC Addr           : 333333-333333
            Serial Number      : SGBBBBBBBB                              
            Memory   - Total   : 69,952,000  
                      Free    : 39,162,196  
 
           Member :2
 
            ROM Version        : WB.16.03                      
            Up Time            : 176 days       
            CPU Util (%)       : 0           
            MAC Addr           : 444444-444444
            Serial Number      : SGCCCCCCCC                              
            Memory   - Total   : 69,952,000  
                      Free    : 54,474,212  
 
           Member :3
 
            ROM Version        : WB.16.03                      
            Up Time            : 176 days       
            CPU Util (%)       : 0           
            MAC Addr           : 555555-555555
            Serial Number      : SGDDDDDDDD                              
            Memory   - Total   : 69,952,000  
                      Free    : 41,157,284  

 b) get_facts result:
				
      All members in stacking have same IP, serial number contains serial numbers of all members:
           'serial_number': 'SGBBBBBBBB SGCCCCCCCC SGDDDDDDDD'
			

> {'uptime': 15213540, 'vendor': 'Hewlett-Packard', 'os_version': 'WB.16.02.0028', 'serial_number': 'SGBBBBBBBB SGCCCCCCCC SGDDDDDDDD', 'model': 'HP 2920 Switch Stack', 'hostname': 'STACK-3-UNITS', 'fqdn': 'Unknown', 'interface_list': ['1/1', '1/2', '1/3', '1/4', '1/5', '1/6', '1/7', '1/8', '1/9', '1/10', '1/11', '1/12', '1/13', '1/14', '1/15', '1/16', '1/17', '1/18', '1/19', '1/20', '1/21', '1/22', '1/23', '1/24', '1/25', '1/26', '1/27', '1/28', '1/29', '1/30', '1/31', '1/32', '1/33', '1/34', '1/35', '1/36', '1/37', '1/38', '1/39', '1/40', '1/41', '1/42', '1/43', '1/44', '1/45', '1/46', '1/47', '1/48', '2/1', '2/2', '2/3', '2/4', '2/5', '2/6', '2/7', '2/8', '2/9', '2/10', '2/11', '2/12', '2/13', '2/14', '2/15', '2/16', '2/17', '2/18', '2/19', '2/20', '2/21', '2/22', '2/23', '2/24', '2/25', '2/26', '2/27', '2/28', '2/29', '2/30', '2/31', '2/32', '2/33', '2/34', '2/35', '2/36', '2/37', '2/38', '2/39', '2/40', '2/41', '2/42', '2/43', '2/44', '2/45', '2/46', '2/47', '2/48', '3/1', '3/2', '3/3', '3/4', '3/5', '3/6', '3/7', '3/8', '3/9', '3/10', '3/11', '3/12', '3/13', '3/14', '3/15', '3/16', '3/17', '3/18', '3/19', '3/20', '3/21', '3/22', '3/23', '3/24', '3/25', '3/26', '3/27', '3/28', '3/29', '3/30', '3/31', '3/32', '3/33', '3/34', '3/35', '3/36', '3/37', '3/38', '3/39', '3/40', '3/41', '3/42', '3/43', '3/44', '3/45', '3/46', '3/47', '3/48']}
 